### PR TITLE
Parcel form clarification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'luhn'
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-sass'
 end
+gem 'font-awesome-rails'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.3)
       i18n (~> 0.5)
+    font-awesome-rails (4.6.3.0)
+      railties (>= 3.2, < 5.1)
     foreman (0.78.0)
       thor (~> 0.19.1)
     globalid (0.3.6)
@@ -234,6 +236,7 @@ DEPENDENCIES
   devise
   factory_girl_rails
   faker
+  font-awesome-rails
   foreman
   haml
   haml-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,6 @@
 //= require bootstrap-sass
 //= require_tree .
 
+$(document).ready(function() {
+  $('.has-tooltip').tooltip();
+});

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -107,7 +107,7 @@ footer {
 
 span.unit{
   padding-left: 6px;
-  color: #888;
+  color: #777;
 }
 
 .form-unit{

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -101,10 +101,6 @@ footer {
   cursor: pointer;
 }
 
-.unit{
-  color: #555;
-}
-
 span.unit{
   padding-left: 6px;
   color: #777;
@@ -113,20 +109,24 @@ span.unit{
 .form-unit{
   position: absolute;
   top: 8px;
-  z-index: 5;
+  color: #555;
 }
 
 .width-unit{
   right: 80%;
-  right: calc(66% + 35px);
+  right: calc(66% + 30px);
 }
 
 .height-unit{
   right: 40%;
-  right: calc(33% + 24px);
+  right: calc(33% + 19px);
 }
 
 .depth-unit{
-  right: 13px;
+  right: 8px;
+}
+
+.form-control.no-bg{
+  background: rgba(0, 0, 0, 0);
 }
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,6 +13,7 @@
  */
 
 @import 'bootstrap-sass';
+@import 'font-awesome';
 
 html{
   height: 100%;
@@ -77,12 +78,16 @@ footer {
   color: #000;
 }
 
+
+
 .parcels-table {
   th{
     text-align: center;
   }
   text-align: center;
 }
+
+
 
 .form-title{
   text-align: center;
@@ -91,3 +96,37 @@ footer {
 .no-padding{
   padding: 0px;
 }
+
+.has-tooltip{
+  cursor: pointer;
+}
+
+.unit{
+  color: #555;
+}
+
+span.unit{
+  padding-left: 6px;
+  color: #888;
+}
+
+.form-unit{
+  position: absolute;
+  top: 8px;
+  z-index: 5;
+}
+
+.width-unit{
+  right: 80%;
+  right: calc(66% + 35px);
+}
+
+.height-unit{
+  right: 40%;
+  right: calc(33% + 24px);
+}
+
+.depth-unit{
+  right: 13px;
+}
+

--- a/app/views/parcels/new.html.haml
+++ b/app/views/parcels/new.html.haml
@@ -21,15 +21,14 @@
       .col-xs-4.no-padding.text-right
         = f.label :depth
       .input-group
-        = f.text_field :width, class: 'form-control'
-        =#TODO REFACTOR CSS SO CLAS CHAINING ISN'T NEEDED
-        .unit.form-unit.width-unit cm
+        = f.text_field :width, class: 'form-control no-bg'
+        .form-unit.width-unit cm
         .input-group-addon x
-        = f.text_field :height, class: 'form-control'
-        .unit.form-unit.height-unit cm
+        = f.text_field :height, class: 'form-control no-bg'
+        .form-unit.height-unit cm
         .input-group-addon x
-        = f.text_field :depth, class: 'form-control'
-        .unit.form-unit.depth-unit cm
+        = f.text_field :depth, class: 'form-control no-bg'
+        .form-unit.depth-unit cm
     .form-group
       = f.label :name
       %i.fa.fa-info-circle.has-tooltip{ 'data-toggle' => 'tooltip', 'data-placement' => 'right', title: t('.parcel_name_tooltip') }

--- a/app/views/parcels/new.html.haml
+++ b/app/views/parcels/new.html.haml
@@ -11,22 +11,28 @@
       = Parcel.model_name.human
     .form-group
       = f.label :weight
+      %span.unit (kg)
       = f.text_field :weight, class: 'form-control'
     .form-group
-      .col-md-4.no-padding
+      .col-xs-4.no-padding
         = f.label :width
-      .col-md-4
+      .col-xs-4.text-center
         = f.label :height
-      .col-md-4.no-padding.text-right
+      .col-xs-4.no-padding.text-right
         = f.label :depth
       .input-group
         = f.text_field :width, class: 'form-control'
+        =#TODO REFACTOR CSS SO CLAS CHAINING ISN'T NEEDED
+        .unit.form-unit.width-unit cm
         .input-group-addon x
         = f.text_field :height, class: 'form-control'
+        .unit.form-unit.height-unit cm
         .input-group-addon x
         = f.text_field :depth, class: 'form-control'
+        .unit.form-unit.depth-unit cm
     .form-group
       = f.label :name
+      %i.fa.fa-info-circle.has-tooltip{ 'data-toggle' => 'tooltip', 'data-placement' => 'right', title: t('.parcel_name_tooltip') }
       = f.text_field :name, class: 'form-control'
   .col-md-4
     .h3.text-center

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -75,6 +75,7 @@ pl:
   parcels:
     new:
       title: Nadaj przesyłkę
+      parcel_name_tooltip: 'Informacja dla użytkowników śledzących przesyłkę'
       button: Nadaj przesyłkę
     index:
       your_parcels: Twoje przesyłki


### PR DESCRIPTION
Dodałem jednostki do pól wagi i wymiarów przesyłki (z jednostkami wewnątrz pola formularza się naużerałem, ale w końcu udało mi się stworzyć responsywne rozwiązanie, które działa).
Dodałem tooltip wyjaśniający pole "nazwa przesyłki". Od teraz mogę korzystać z bootstrapowych tooltipów na stronie.
