### PR TITLE
Add acceptance to parcel

### DIFF
--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -3,7 +3,7 @@ class Parcel < ActiveRecord::Base
   belongs_to :sender_info
   belongs_to :recipient_info
 
-  enum acceptance: {
+  enum acceptance_status: {
     awaiting: 0,
     accepted: 1,
     rejected: 2
@@ -16,7 +16,7 @@ class Parcel < ActiveRecord::Base
 
   attr_localized :price, :weight
 
-  validates :width, :height, :depth, :weight, :price, :parcel_number, :sender_info, :recipient_info, :acceptance, presence: true
+  validates :width, :height, :depth, :weight, :price, :parcel_number, :sender_info, :recipient_info, :acceptance_status, presence: true
   validates :weight, :price, numericality: { greater_than: 0 }
   validates :height, :depth, :width, numericality: { only_integer: true, greater_than: 0 }
   validates :parcel_number, uniqueness: true

--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -3,6 +3,12 @@ class Parcel < ActiveRecord::Base
   belongs_to :sender_info
   belongs_to :recipient_info
 
+  enum acceptance: {
+    awaiting: 0,
+    accepted: 1,
+    rejected: 2
+  }
+
   delegate :city, to: :recipient_info, prefix: :recipient
 
   accepts_nested_attributes_for :sender_info
@@ -10,7 +16,7 @@ class Parcel < ActiveRecord::Base
 
   attr_localized :price, :weight
 
-  validates :width, :height, :depth, :weight, :price, :parcel_number, :sender_info, :recipient_info, presence: true
+  validates :width, :height, :depth, :weight, :price, :parcel_number, :sender_info, :recipient_info, :acceptance, presence: true
   validates :weight, :price, numericality: { greater_than: 0 }
   validates :height, :depth, :width, numericality: { only_integer: true, greater_than: 0 }
   validates :parcel_number, uniqueness: true

--- a/db/migrate/20160523212454_add_acceptance_to_parcel.rb
+++ b/db/migrate/20160523212454_add_acceptance_to_parcel.rb
@@ -1,5 +1,5 @@
 class AddAcceptanceToParcel < ActiveRecord::Migration
   def change
-    add_column :parcels, :acceptance, :integer, null: false, default: 0
+    add_column :parcels, :acceptance_status, :integer, null: false, default: 0
   end
 end

--- a/db/migrate/20160523212454_add_acceptance_to_parcel.rb
+++ b/db/migrate/20160523212454_add_acceptance_to_parcel.rb
@@ -1,0 +1,5 @@
+class AddAcceptanceToParcel < ActiveRecord::Migration
+  def change
+    add_column :parcels, :acceptance, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20160523212454) do
     t.string   "parcel_number",     limit: 20,                                     null: false
     t.integer  "sender_info_id",                                                   null: false
     t.integer  "recipient_info_id",                                                null: false
-    t.integer  "acceptance",                                           default: 0, null: false
+    t.integer  "acceptance_status",                                    default: 0, null: false
   end
 
   add_index "parcels", ["parcel_number"], name: "index_parcels_on_parcel_number", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,24 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160521194430) do
+ActiveRecord::Schema.define(version: 20160523212454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "parcels", force: :cascade do |t|
     t.string   "name"
-    t.integer  "width",                                                null: false
-    t.integer  "height",                                               null: false
-    t.integer  "depth",                                                null: false
-    t.decimal  "weight",                       precision: 6, scale: 2, null: false
-    t.decimal  "price",                        precision: 6, scale: 2, null: false
-    t.datetime "created_at",                                           null: false
-    t.datetime "updated_at",                                           null: false
+    t.integer  "width",                                                            null: false
+    t.integer  "height",                                                           null: false
+    t.integer  "depth",                                                            null: false
+    t.decimal  "weight",                       precision: 6, scale: 2,             null: false
+    t.decimal  "price",                        precision: 6, scale: 2,             null: false
+    t.datetime "created_at",                                                       null: false
+    t.datetime "updated_at",                                                       null: false
     t.integer  "sender_id"
-    t.string   "parcel_number",     limit: 20,                         null: false
-    t.integer  "sender_info_id",                                       null: false
-    t.integer  "recipient_info_id",                                    null: false
+    t.string   "parcel_number",     limit: 20,                                     null: false
+    t.integer  "sender_info_id",                                                   null: false
+    t.integer  "recipient_info_id",                                                null: false
+    t.integer  "acceptance",                                           default: 0, null: false
   end
 
   add_index "parcels", ["parcel_number"], name: "index_parcels_on_parcel_number", unique: true, using: :btree

--- a/spec/factories/parcels.rb
+++ b/spec/factories/parcels.rb
@@ -19,5 +19,13 @@ FactoryGirl.define do
     trait :invalid do
       width nil
     end
+
+    trait :accepted do
+      acceptance 'accepted'
+    end
+
+    trait :rejected do
+      acceptance 'rejected'
+    end
   end
 end

--- a/spec/factories/parcels.rb
+++ b/spec/factories/parcels.rb
@@ -21,11 +21,11 @@ FactoryGirl.define do
     end
 
     trait :accepted do
-      acceptance 'accepted'
+      acceptance_status 'accepted'
     end
 
     trait :rejected do
-      acceptance 'rejected'
+      acceptance_status 'rejected'
     end
   end
 end

--- a/spec/models/parcel_spec.rb
+++ b/spec/models/parcel_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Parcel, type: :model do
     end
   end
 
-  it { should define_enum_for(:acceptance) }
+  it { should define_enum_for(:acceptance_status) }
 
-  describe 'acceptance' do
+  describe 'acceptance status -' do
     let(:parcel)  { FactoryGirl.create(:parcel) }
 
     it 'awaiting status is assigned by default' do
@@ -52,14 +52,14 @@ RSpec.describe Parcel, type: :model do
     end
 
     it 'accepted status is assigned through value 1' do
-      parcel.update(acceptance: 1)
+      parcel.update(acceptance_status: 1)
       expect(parcel.awaiting?).to be false
       expect(parcel.accepted?).to be true
       expect(parcel.rejected?).to be false
     end
 
     it 'rejected status is assigned through value 2' do
-      parcel.update(acceptance: 2)
+      parcel.update(acceptance_status: 2)
       expect(parcel.awaiting?).to be false
       expect(parcel.accepted?).to be false
       expect(parcel.rejected?).to be true

--- a/spec/models/parcel_spec.rb
+++ b/spec/models/parcel_spec.rb
@@ -39,4 +39,30 @@ RSpec.describe Parcel, type: :model do
       expect(Luhn.valid?(parcel.parcel_number)).to be true
     end
   end
+
+  it { should define_enum_for(:acceptance) }
+
+  describe 'acceptance' do
+    let(:parcel)  { FactoryGirl.create(:parcel) }
+
+    it 'awaiting status is assigned by default' do
+      expect(parcel.awaiting?).to be true
+      expect(parcel.accepted?).to be false
+      expect(parcel.rejected?).to be false
+    end
+
+    it 'accepted status is assigned through value 1' do
+      parcel.update(acceptance: 1)
+      expect(parcel.awaiting?).to be false
+      expect(parcel.accepted?).to be true
+      expect(parcel.rejected?).to be false
+    end
+
+    it 'rejected status is assigned through value 2' do
+      parcel.update(acceptance: 2)
+      expect(parcel.awaiting?).to be false
+      expect(parcel.accepted?).to be false
+      expect(parcel.rejected?).to be true
+    end
+  end
 end


### PR DESCRIPTION
Drugi enum - ma za zadanie opisywać status przesyłki - czy jest przyjęta przez firmę, czy też coś się nie zgadza i nie będzie obsłużona
