### PR TITLE
Employee can accept order

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -133,3 +133,11 @@ span.unit{
 .table > thead > tr > th, .table > thead > tr > td, .table > tbody > tr > th, .table > tbody > tr > td, .table > tfoot > tr > th, .table > tfoot > tr > td{
   vertical-align: middle;
 }
+
+.rejected-parcels > .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: #ffe9e9;
+}
+
+.accepted-parcels > .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: #e9ffe9;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -142,6 +142,15 @@ span.unit{
     background-color: #e0ffe0;
 }
 
+.information-list > tbody > tr > td:nth-of-type(odd){
+  font-weight: bold;
+  text-align: right;
+}
+
+.information-list > tbody > tr > td:nth-of-type(even){
+  text-align: left;
+}
+
 .btn.inactive{
   opacity: 0.5;
   cursor: default;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -139,7 +139,7 @@ span.unit{
 }
 
 .accepted-parcels > .table-striped > tbody > tr:nth-of-type(odd) {
-    background-color: #e9ffe9;
+    background-color: #e0ffe0;
 }
 
 .btn.inactive{

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -80,7 +80,7 @@ footer {
 
 
 
-.parcels-table {
+.centered-text-table {
   th{
     text-align: center;
   }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -141,3 +141,9 @@ span.unit{
 .accepted-parcels > .table-striped > tbody > tr:nth-of-type(odd) {
     background-color: #e9ffe9;
 }
+
+.btn.inactive{
+  opacity: 0.5;
+  cursor: default;
+  box-shadow: none;
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,6 +14,7 @@ class Admin::UsersController < AdminController
       flash[:alert] = t('errors.messages.not_authorized')
     else
       edited_user.update!(user_params) 
+      flash[:notice] = t('.role_changed_succesfully')
     end
     redirect_to action: "index"
   end

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -14,7 +14,7 @@ class Employee::ParcelsController < EmployeeController
     parcel = Parcel.find(params[:id])
     acceptance_status = parcel_params[:acceptance_status]
     author = current_user
-    additional_info = parcel_params[:operations_attributes]['0'][:additional_info]
+    additional_info = parcel_params[:operation][:additional_info]
     service = ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info)
     if service.call
       flash[:notice] = t('.acceptance_status_changed_succesfully')
@@ -28,6 +28,6 @@ class Employee::ParcelsController < EmployeeController
 
   def parcel_params
     params.require(:parcel).permit(:acceptance_status,
-      operations_attributes: [:additional_info])
+      operation: [:additional_info])
   end
 end

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -8,6 +8,7 @@ class Employee::ParcelsController < EmployeeController
 
   def edit
     @parcel = Parcel.find(params[:id])
+    @operations = @parcel.operations.newest_first
   end
 
   def update

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -12,7 +12,10 @@ class Employee::ParcelsController < EmployeeController
 
   def update
     parcel = Parcel.find(params[:id])
-    service = ParcelAcceptanceService.new(parcel, parcel_params[:acceptance_status], current_user)
+    acceptance_status = parcel_params[:acceptance_status]
+    author = current_user
+    additional_info = parcel_params[:operations_attributes][:additional_info]
+    service = ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info)
     if service.call
       flash[:notice] = t('.acceptance_status_changed_succesfully')
     else
@@ -24,6 +27,7 @@ class Employee::ParcelsController < EmployeeController
   private
 
   def parcel_params
-    params.require(:parcel).permit(:acceptance_status)
+    params.require(:parcel).permit(:acceptance_status,
+      operations_attributes: [:additional_info])
   end
 end

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -1,13 +1,9 @@
 class Employee::ParcelsController < EmployeeController
 
   def index
-<<<<<<< HEAD
     @pending_parcels = Parcel.pending.newest_first
     @accepted_parcels = Parcel.accepted.newest_first
     @rejected_parcels = Parcel.rejected.newest_first
-=======
-    @parcels = Parcel.newest_first
->>>>>>> employee_parcels_controller
   end
 
   def edit

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -12,7 +12,12 @@ class Employee::ParcelsController < EmployeeController
 
   def update
     parcel = Parcel.find(params[:id])
-    ParcelAcceptanceService.new(parcel, parcel_params[:acceptance_status], current_user).call
+    service = ParcelAcceptanceService.new(parcel, parcel_params[:acceptance_status], current_user)
+    if service.call
+      flash[:notice] = t('.acceptance_status_changed_succesfully')
+    else
+      flash[:alert] = t('.acceptance_status_change_not_possible')
+    end
     redirect_to action: "index"
   end
 

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -14,7 +14,7 @@ class Employee::ParcelsController < EmployeeController
     parcel = Parcel.find(params[:id])
     acceptance_status = parcel_params[:acceptance_status]
     author = current_user
-    additional_info = parcel_params[:operations_attributes][:additional_info]
+    additional_info = parcel_params[:operations_attributes]['0'][:additional_info]
     service = ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info)
     if service.call
       flash[:notice] = t('.acceptance_status_changed_succesfully')

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -4,9 +4,9 @@ class Employee::ParcelsController < EmployeeController
     @parcels = Parcel.all
   end
 
-  # def edit
-  #   @parcel = Parcel.find(params[:id])
-  # end
+  def edit
+    @parcel = Parcel.find(params[:id])
+  end
 
   # def update
   #   parcel = Parcel.find(params[:id])

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -14,7 +14,7 @@ class Employee::ParcelsController < EmployeeController
   def update
     parcel = Parcel.find(params[:id])
     acceptance_status = parcel_params[:acceptance_status]
-    author = current_user
+    author = current_employee
     additional_info = parcel_params[:operation][:additional_info]
     service = ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info)
     if service.call

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -12,11 +12,8 @@ class Employee::ParcelsController < EmployeeController
 
   def update
     parcel = Parcel.find(params[:id])
-    unless parcel.acceptance_status == parcel_params[:acceptance_status]
-      parcel.accept!(current_user) if parcel_params[:acceptance_status] == 'accepted'
-      parcel.reject!(current_user) if parcel_params[:acceptance_status] == 'rejected'
-      flash[:notice] = t('.acceptance_status_changed_succesfully')
-    end
+    parcel.accept!(current_user) if parcel_params[:acceptance_status] == 'accepted'
+    parcel.reject!(current_user) if parcel_params[:acceptance_status] == 'rejected'
     redirect_to action: "index"
   end
 

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -12,8 +12,7 @@ class Employee::ParcelsController < EmployeeController
 
   def update
     parcel = Parcel.find(params[:id])
-    parcel.accept!(current_user) if parcel_params[:acceptance_status] == 'accepted'
-    parcel.reject!(current_user) if parcel_params[:acceptance_status] == 'rejected'
+    ParcelAcceptanceService.new(parcel, parcel_params[:acceptance_status], current_user).call
     redirect_to action: "index"
   end
 

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -15,6 +15,7 @@ class Employee::ParcelsController < EmployeeController
     unless parcel.acceptance_status == parcel_params[:acceptance_status]
       parcel.accept!(current_user) if parcel_params[:acceptance_status] == 'accepted'
       parcel.reject!(current_user) if parcel_params[:acceptance_status] == 'rejected'
+      flash[:notice] = t('.acceptance_status_changed_succesfully')
     end
     redirect_to action: "index"
   end

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -1,7 +1,9 @@
 class Employee::ParcelsController < EmployeeController
 
   def index
-    @parcels = Parcel.all
+    @pending_parcels = Parcel.pending.newest_first
+    @accepted_parcels = Parcel.accepted.newest_first
+    @rejected_parcels = Parcel.rejected.newest_first
   end
 
   def edit

--- a/app/controllers/employee/parcels_controller.rb
+++ b/app/controllers/employee/parcels_controller.rb
@@ -10,15 +10,18 @@ class Employee::ParcelsController < EmployeeController
     @parcel = Parcel.find(params[:id])
   end
 
-  # def update
-  #   parcel = Parcel.find(params[:id])
-  #   parcel.update!(parcel_params)
-  #   redirect_to action: "index"
-  # end
+  def update
+    parcel = Parcel.find(params[:id])
+    unless parcel.acceptance_status == parcel_params[:acceptance_status]
+      parcel.accept!(current_user) if parcel_params[:acceptance_status] == 'accepted'
+      parcel.reject!(current_user) if parcel_params[:acceptance_status] == 'rejected'
+    end
+    redirect_to action: "index"
+  end
 
-  # private
+  private
 
-  # def parcel_params
-  #   params.require(:parcel)
-  # end
+  def parcel_params
+    params.require(:parcel).permit(:acceptance_status)
+  end
 end

--- a/app/controllers/employee_controller.rb
+++ b/app/controllers/employee_controller.rb
@@ -6,4 +6,8 @@ class EmployeeController < ApplicationController
       redirect_to root_path , alert: t('errors.messages.not_authorized')
     end
   end
+
+  def current_employee
+    current_user
+  end
 end

--- a/app/helpers/enum_helper.rb
+++ b/app/helpers/enum_helper.rb
@@ -1,5 +1,4 @@
 module EnumHelper
-
   def translate_role(role)
     I18n.t("activerecord.attributes.user.roles.#{role}")
   end
@@ -8,5 +7,9 @@ module EnumHelper
     User.roles.keys.map do |role|
       [translate_role(role), role]
     end
+  end
+
+  def translate_kind(kind)
+    I18n.t("activerecord.attributes.operation.kinds.#{kind}")
   end
 end

--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -5,6 +5,7 @@ class Operation < ActiveRecord::Base
   validates :kind, :parcel, presence: true
 
   scope :newest_first, -> { order(created_at: :desc) }
+  scope :acceptance, -> { where(kind: [1, 2]) }
 
   enum kind: {
     order_created: 0,

--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -7,6 +7,8 @@ class Operation < ActiveRecord::Base
   scope :newest_first, -> { order(created_at: :desc) }
   scope :acceptance, -> { where(kind: [1, 2]) }
 
+  delegate :email, to: :user, prefix: :author
+
   enum kind: {
     order_created: 0,
     order_accepted: 1,

--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -12,6 +12,9 @@ class Parcel < ActiveRecord::Base
   }
 
   delegate :city, to: :recipient_info, prefix: :recipient
+  delegate :zip_code, to: :recipient_info, prefix: :recipient
+  delegate :city, to: :sender_info, prefix: :sender
+  delegate :zip_code, to: :sender_info, prefix: :sender
 
   accepts_nested_attributes_for :sender_info
   accepts_nested_attributes_for :recipient_info

--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -31,17 +31,17 @@ class Parcel < ActiveRecord::Base
   scope :newest_first, -> { order(created_at: :desc) }
 
   def accept!(author=nil)
-    self.update(acceptance_status: 'accepted')
-    operation = Operation.new(parcel: self, kind: 'order_accepted')
-    operation.user = author if author
-    operation.save!
+    unless self.accepted?
+      self.update(acceptance_status: 'accepted')
+      Operation.create(parcel: self, kind: 'order_accepted', user: author)
+    end
   end
 
   def reject!(author=nil)
-    self.update(acceptance_status: 'rejected')
-    operation = Operation.new(parcel: self, kind: 'order_rejected')
-    operation.user = author if author
-    operation.save!
+    unless self.rejected?
+      self.update(acceptance_status: 'rejected')
+      Operation.create(parcel: self, kind: 'order_rejected', user: author)
+    end
   end
 
   private

--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -18,6 +18,7 @@ class Parcel < ActiveRecord::Base
 
   accepts_nested_attributes_for :sender_info
   accepts_nested_attributes_for :recipient_info
+  accepts_nested_attributes_for :operations
 
   attr_localized :price, :weight
 

--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -11,11 +11,6 @@ class Parcel < ActiveRecord::Base
     rejected: 2
   }
 
-  delegate :city, to: :recipient_info, prefix: :recipient
-  delegate :zip_code, to: :recipient_info, prefix: :recipient
-  delegate :city, to: :sender_info, prefix: :sender
-  delegate :zip_code, to: :sender_info, prefix: :sender
-
   accepts_nested_attributes_for :sender_info
   accepts_nested_attributes_for :recipient_info
   accepts_nested_attributes_for :operations
@@ -31,6 +26,17 @@ class Parcel < ActiveRecord::Base
 
   before_validation :set_price, :generate_parcel_number, on: :create
   after_create :create_order_created_operation
+
+  delegate :city, to: :recipient_info, prefix: :recipient
+  delegate :city, to: :sender_info, prefix: :sender
+
+  def from
+    sender_info.basic_address
+  end
+
+  def to
+    recipient_info.basic_address
+  end
 
   private
 

--- a/app/models/recipient_info.rb
+++ b/app/models/recipient_info.rb
@@ -3,4 +3,8 @@ class RecipientInfo < ActiveRecord::Base
   
   validates :email, :contact_name, :zip_code, :address, :city, :phone_number, presence: true
   validates_format_of :email, with: Devise::email_regexp
+
+  def basic_address
+    "#{zip_code} #{city}"
+  end
 end

--- a/app/models/sender_info.rb
+++ b/app/models/sender_info.rb
@@ -3,4 +3,8 @@ class SenderInfo < ActiveRecord::Base
 
   validates :email, :contact_name, :zip_code, :address, :city, :phone_number, presence: true
   validates_format_of :email, with: Devise::email_regexp
+
+  def basic_address
+    "#{zip_code} #{city}"
+  end
 end

--- a/app/services/parcel_acceptance_service.rb
+++ b/app/services/parcel_acceptance_service.rb
@@ -1,16 +1,17 @@
 class ParcelAcceptanceService
 
-  def initialize(parcel, acceptance_status, author=nil)
+  def initialize(parcel, acceptance_status, author=nil, additional_info=nil)
     @parcel = parcel
     @acceptance_status = acceptance_status
     @author = author
+    @additional_info = additional_info
   end
 
   def call
     return false unless valid_request
     Parcel.transaction do
       @parcel.update!(acceptance_status: @acceptance_status)
-      Operation.create!(parcel: @parcel, kind: operation_kind, user: @author)
+      Operation.create!(parcel: @parcel, kind: operation_kind, user: @author, additional_info: @additional_info)
       true
     end
   end

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -1,6 +1,6 @@
 %h1
   = @user.email
-%table.table.table-striped.parcels-table
+%table.table.table-striped.centered-text-table
   %thead
     %tr
       %th= User.human_attribute_name('email')

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,6 +1,6 @@
 %h1
   = t('.users')
-%table.table.table-striped.parcels-table
+%table.table.table-striped.centered-text-table
   %thead
     %tr
       %th= User.human_attribute_name('email')

--- a/app/views/employee/parcels/_delivery_info_table.haml
+++ b/app/views/employee/parcels/_delivery_info_table.haml
@@ -1,0 +1,29 @@
+%table.table.information-list
+  %tbody
+    %tr
+      %td= SenderInfo.human_attribute_name('email')
+      %td= info.email
+    %tr
+      %td= SenderInfo.human_attribute_name('phone_number')
+      %td= info.phone_number
+    %tr
+      %td= SenderInfo.human_attribute_name('company_name')
+      %td= info.company_name
+    %tr
+      %td= SenderInfo.human_attribute_name('contact_name')
+      %td= info.contact_name
+    %tr
+      %td= SenderInfo.human_attribute_name('address')
+      %td= info.address
+    %tr
+      %td= SenderInfo.human_attribute_name('city')
+      %td= info.city
+    %tr
+      %td= SenderInfo.human_attribute_name('zip_code')
+      %td= info.zip_code
+    %tr
+      %td= SenderInfo.human_attribute_name('residential')
+      %td= t info.residential?.to_s
+    %tr
+      %td= SenderInfo.human_attribute_name('other_info')
+      %td= info.other_info

--- a/app/views/employee/parcels/_parcel_table.haml
+++ b/app/views/employee/parcels/_parcel_table.haml
@@ -4,8 +4,8 @@
       %th= Parcel.human_attribute_name('parcel_number')
       %th= Parcel.human_attribute_name('weight')
       %th= Parcel.human_attribute_name('price')
-      %th= t('.from')
-      %th= t('.to')
+      %th= Parcel.human_attribute_name('from')
+      %th= Parcel.human_attribute_name('to')
       %th= Parcel.human_attribute_name('created_at')
       %th= Parcel.human_attribute_name('name')
   %tbody

--- a/app/views/employee/parcels/_parcel_table.haml
+++ b/app/views/employee/parcels/_parcel_table.haml
@@ -11,7 +11,7 @@
   %tbody
     - parcels.each do |parcel|
       %tr
-        %td= parcel.parcel_number
+        %td= link_to parcel.parcel_number, edit_employee_parcel_path(parcel)
         %td= number_to_kg(parcel.weight)
         %td= number_to_currency(parcel.price)
         %td= "#{parcel.sender_zip_code} #{parcel.sender_city}"

--- a/app/views/employee/parcels/_parcel_table.haml
+++ b/app/views/employee/parcels/_parcel_table.haml
@@ -4,6 +4,8 @@
       %th= Parcel.human_attribute_name('parcel_number')
       %th= Parcel.human_attribute_name('weight')
       %th= Parcel.human_attribute_name('price')
+      %th= t('.from')
+      %th= t('.to')
       %th= Parcel.human_attribute_name('created_at')
       %th= Parcel.human_attribute_name('name')
   %tbody
@@ -12,5 +14,7 @@
         %td= parcel.parcel_number
         %td= number_to_kg(parcel.weight)
         %td= number_to_currency(parcel.price)
+        %td= "#{parcel.sender_zip_code} #{parcel.sender_city}"
+        %td= "#{parcel.recipient_zip_code} #{parcel.recipient_city}"
         %td= l parcel.created_at
         %td= parcel.name

--- a/app/views/employee/parcels/_parcel_table.haml
+++ b/app/views/employee/parcels/_parcel_table.haml
@@ -1,4 +1,4 @@
-%table.table.table-striped.parcels-table
+%table.table.table-striped.centered-text-table
   %thead
     %tr
       %th= Parcel.human_attribute_name('parcel_number')

--- a/app/views/employee/parcels/_parcel_table.haml
+++ b/app/views/employee/parcels/_parcel_table.haml
@@ -14,7 +14,7 @@
         %td= link_to parcel.parcel_number, edit_employee_parcel_path(parcel)
         %td= number_to_kg(parcel.weight)
         %td= number_to_currency(parcel.price)
-        %td= "#{parcel.sender_zip_code} #{parcel.sender_city}"
-        %td= "#{parcel.recipient_zip_code} #{parcel.recipient_city}"
+        %td= parcel.from
+        %td= parcel.to
         %td= l parcel.created_at
         %td= parcel.name

--- a/app/views/employee/parcels/_parcel_table.haml
+++ b/app/views/employee/parcels/_parcel_table.haml
@@ -1,0 +1,16 @@
+%table.table.table-striped.parcels-table
+  %thead
+    %tr
+      %th= Parcel.human_attribute_name('parcel_number')
+      %th= Parcel.human_attribute_name('weight')
+      %th= Parcel.human_attribute_name('price')
+      %th= Parcel.human_attribute_name('created_at')
+      %th= Parcel.human_attribute_name('name')
+  %tbody
+    - parcels.each do |parcel|
+      %tr
+        %td= parcel.parcel_number
+        %td= number_to_kg(parcel.weight)
+        %td= number_to_currency(parcel.price)
+        %td= l parcel.created_at
+        %td= parcel.name

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -24,17 +24,15 @@
 .col-md-6.text-center
   %h3 Odbiorca
   = render 'delivery_info_table', info: @parcel.recipient_info
-.col-xs-6
-  -unless @parcel.accepted?
-    = form_for [:employee, @parcel] do |f|
-      = f.hidden_field :acceptance_status, value: 'accepted'
-      = f.submit t('.accept'), class: 'btn btn-success pull-right'
-  -else
-    .btn.btn-success.pull-right.inactive= t('.accept')
-.col-xs-6
-  -unless @parcel.rejected?
-    = form_for [:employee, @parcel] do |f|
-      = f.hidden_field :acceptance_status, value: 'rejected'
-      = f.submit t('.reject'), class: 'btn btn-danger'
-  -else
-    .btn.btn-danger.inactive= t('.reject')
+= form_for [:employee, @parcel] do |f|
+  = f.hidden_field :acceptance_status
+  .col-xs-6
+    -unless @parcel.accepted?
+      = f.submit t('.accept'), class: 'btn btn-success pull-right', onclick: "document.getElementById('parcel_acceptance_status').value = 'accepted'"
+    -else
+      .btn.btn-success.pull-right.inactive= t('.accept')
+  .col-xs-6
+    -unless @parcel.rejected?
+      = f.submit t('.reject'), class: 'btn btn-danger', onclick: "document.getElementById('parcel_acceptance_status').value = 'rejected'"
+    -else
+      .btn.btn-danger.inactive= t('.reject')

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -30,7 +30,7 @@
     = f.hidden_field :acceptance_status
     .form-group
       = f.fields_for :operation do |o|
-        = o.label :additional_info
+        = o.label :additional_info, t('.comment')
         = o.text_area :additional_info, class: 'form-control'
     .col-xs-6
       -unless @parcel.accepted?

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -44,17 +44,19 @@
         .btn.btn-danger.inactive= t('.reject')
 -if @operations.count > 0
   .row
-    %h4 Wcześniejsze operacje
+    %h4= t('.previous_operations')
   %table.table.table-striped.centered-text-table
     %thead
       %tr
         %th= Operation.human_attribute_name('kind')
         %th= Operation.human_attribute_name('created_at')
         %th= Operation.human_attribute_name('additional_info')
+        %th= Operation.human_attribute_name('user')
     %tbody
       - @operations.each do |operation|
         %tr
           %td= translate_kind(operation.kind)
           %td= l operation.created_at
           %td= operation.additional_info
+          %td= operation.author_email if operation.user
 

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -18,6 +18,12 @@
       %td= "#{@parcel.recipient_zip_code} #{@parcel.recipient_city}"
       %td= l @parcel.created_at
       %td= @parcel.name
+.col-md-6.text-center
+  %h3 Nadawca
+  = render 'delivery_info_table', info: @parcel.sender_info
+.col-md-6.text-center
+  %h3 Odbiorca
+  = render 'delivery_info_table', info: @parcel.recipient_info
 .col-xs-6
   -unless @parcel.accepted?
     = form_for [:employee, @parcel] do |f|

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -42,3 +42,19 @@
         = f.submit t('.reject'), class: 'btn btn-danger', onclick: "document.getElementById('parcel_acceptance_status').value = 'rejected'"
       -else
         .btn.btn-danger.inactive= t('.reject')
+-if @operations.count > 0
+  .row
+    %h4 Wcześniejsze operacje
+  %table.table.table-striped.centered-text-table
+    %thead
+      %tr
+        %th= Operation.human_attribute_name('kind')
+        %th= Operation.human_attribute_name('created_at')
+        %th= Operation.human_attribute_name('additional_info')
+    %tbody
+      - @operations.each do |operation|
+        %tr
+          %td= translate_kind(operation.kind)
+          %td= l operation.created_at
+          %td= operation.additional_info
+

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -20,10 +20,10 @@
       %td= @parcel.name
 .row
   .col-md-6.text-center
-    %h3 Nadawca
+    %h3= t('.sender')
     = render 'delivery_info_table', info: @parcel.sender_info
   .col-md-6.text-center
-    %h3 Odbiorca
+    %h3= t('.recipient')
     = render 'delivery_info_table', info: @parcel.recipient_info
 .row
   = form_for [:employee, @parcel] do |f|

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -1,7 +1,7 @@
 =link_to t('navigation.back'), employee_parcels_path
 %h1
   =t('.parcel_no', parcel_number: @parcel.parcel_number)
-%table.table.table-striped.parcels-table
+%table.table.parcels-table
   %thead
     %tr
       %th= Parcel.human_attribute_name('weight')

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -1,7 +1,7 @@
 =link_to t('navigation.back'), employee_parcels_path
 %h1
   =t('.parcel_no', parcel_number: @parcel.parcel_number)
-%table.table.parcels-table
+%table.table.centered-text-table
   %thead
     %tr
       %th= Parcel.human_attribute_name('weight')

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -26,6 +26,10 @@
   = render 'delivery_info_table', info: @parcel.recipient_info
 = form_for [:employee, @parcel] do |f|
   = f.hidden_field :acceptance_status
+  .form-group
+    = f.fields_for :operations do |o|
+      = o.label :additional_info
+      = o.text_area :additional_info, class: 'form-control'
   .col-xs-6
     -unless @parcel.accepted?
       = f.submit t('.accept'), class: 'btn btn-success pull-right', onclick: "document.getElementById('parcel_acceptance_status').value = 'accepted'"

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -17,3 +17,11 @@
       %td= "#{@parcel.recipient_zip_code} #{@parcel.recipient_city}"
       %td= l @parcel.created_at
       %td= @parcel.name
+.col-xs-6
+  = form_for [:employee, @parcel] do |f|
+    = f.hidden_field :acceptance_status, value: 'accepted'
+    = f.submit t('.accept'), class: 'btn btn-success pull-right'
+.col-xs-6
+  = form_for [:employee, @parcel] do |f|
+    = f.hidden_field :acceptance_status, value: 'rejected'
+    = f.submit t('.reject'), class: 'btn btn-danger'

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -1,3 +1,4 @@
+=link_to t('navigation.back'), employee_parcels_path
 %h1
   =t('.parcel_no', parcel_number: @parcel.parcel_number)
 %table.table.table-striped.parcels-table
@@ -18,10 +19,16 @@
       %td= l @parcel.created_at
       %td= @parcel.name
 .col-xs-6
-  = form_for [:employee, @parcel] do |f|
-    = f.hidden_field :acceptance_status, value: 'accepted'
-    = f.submit t('.accept'), class: 'btn btn-success pull-right'
+  -unless @parcel.accepted?
+    = form_for [:employee, @parcel] do |f|
+      = f.hidden_field :acceptance_status, value: 'accepted'
+      = f.submit t('.accept'), class: 'btn btn-success pull-right'
+  -else
+    .btn.btn-success.pull-right.inactive= t('.accept')
 .col-xs-6
-  = form_for [:employee, @parcel] do |f|
-    = f.hidden_field :acceptance_status, value: 'rejected'
-    = f.submit t('.reject'), class: 'btn btn-danger'
+  -unless @parcel.rejected?
+    = form_for [:employee, @parcel] do |f|
+      = f.hidden_field :acceptance_status, value: 'rejected'
+      = f.submit t('.reject'), class: 'btn btn-danger'
+  -else
+    .btn.btn-danger.inactive= t('.reject')

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -18,25 +18,27 @@
       %td= "#{@parcel.recipient_zip_code} #{@parcel.recipient_city}"
       %td= l @parcel.created_at
       %td= @parcel.name
-.col-md-6.text-center
-  %h3 Nadawca
-  = render 'delivery_info_table', info: @parcel.sender_info
-.col-md-6.text-center
-  %h3 Odbiorca
-  = render 'delivery_info_table', info: @parcel.recipient_info
-= form_for [:employee, @parcel] do |f|
-  = f.hidden_field :acceptance_status
-  .form-group
-    = f.fields_for :operations do |o|
-      = o.label :additional_info
-      = o.text_area :additional_info, class: 'form-control'
-  .col-xs-6
-    -unless @parcel.accepted?
-      = f.submit t('.accept'), class: 'btn btn-success pull-right', onclick: "document.getElementById('parcel_acceptance_status').value = 'accepted'"
-    -else
-      .btn.btn-success.pull-right.inactive= t('.accept')
-  .col-xs-6
-    -unless @parcel.rejected?
-      = f.submit t('.reject'), class: 'btn btn-danger', onclick: "document.getElementById('parcel_acceptance_status').value = 'rejected'"
-    -else
-      .btn.btn-danger.inactive= t('.reject')
+.row
+  .col-md-6.text-center
+    %h3 Nadawca
+    = render 'delivery_info_table', info: @parcel.sender_info
+  .col-md-6.text-center
+    %h3 Odbiorca
+    = render 'delivery_info_table', info: @parcel.recipient_info
+.row
+  = form_for [:employee, @parcel] do |f|
+    = f.hidden_field :acceptance_status
+    .form-group
+      = f.fields_for :operations do |o|
+        = o.label :additional_info
+        = o.text_area :additional_info, class: 'form-control'
+    .col-xs-6
+      -unless @parcel.accepted?
+        = f.submit t('.accept'), class: 'btn btn-success pull-right', onclick: "document.getElementById('parcel_acceptance_status').value = 'accepted'"
+      -else
+        .btn.btn-success.pull-right.inactive= t('.accept')
+    .col-xs-6
+      -unless @parcel.rejected?
+        = f.submit t('.reject'), class: 'btn btn-danger', onclick: "document.getElementById('parcel_acceptance_status').value = 'rejected'"
+      -else
+        .btn.btn-danger.inactive= t('.reject')

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -14,8 +14,8 @@
     %tr
       %td= number_to_kg(@parcel.weight)
       %td= number_to_currency(@parcel.price)
-      %td= "#{@parcel.sender_zip_code} #{@parcel.sender_city}"
-      %td= "#{@parcel.recipient_zip_code} #{@parcel.recipient_city}"
+      %td= parcel.from
+      %td= parcel.to
       %td= l @parcel.created_at
       %td= @parcel.name
 .row

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -29,7 +29,7 @@
   = form_for [:employee, @parcel] do |f|
     = f.hidden_field :acceptance_status
     .form-group
-      = f.fields_for :operations do |o|
+      = f.fields_for :operation do |o|
         = o.label :additional_info
         = o.text_area :additional_info, class: 'form-control'
     .col-xs-6

--- a/app/views/employee/parcels/edit.html.haml
+++ b/app/views/employee/parcels/edit.html.haml
@@ -1,0 +1,19 @@
+%h1
+  =t('.parcel_no', parcel_number: @parcel.parcel_number)
+%table.table.table-striped.parcels-table
+  %thead
+    %tr
+      %th= Parcel.human_attribute_name('weight')
+      %th= Parcel.human_attribute_name('price')
+      %th= Parcel.human_attribute_name('from')
+      %th= Parcel.human_attribute_name('to')
+      %th= Parcel.human_attribute_name('created_at')
+      %th= Parcel.human_attribute_name('name')
+  %tbody
+    %tr
+      %td= number_to_kg(@parcel.weight)
+      %td= number_to_currency(@parcel.price)
+      %td= "#{@parcel.sender_zip_code} #{@parcel.sender_city}"
+      %td= "#{@parcel.recipient_zip_code} #{@parcel.recipient_city}"
+      %td= l @parcel.created_at
+      %td= @parcel.name

--- a/app/views/employee/parcels/index.html.haml
+++ b/app/views/employee/parcels/index.html.haml
@@ -1,9 +1,9 @@
-%h1 Przesyłki
-%h3 Oczekujące
+%h1= t('.parcels')
+%h3= t('.pending')
 = render 'parcel_table', parcels: @pending_parcels
-%h3 Odrzucone
+%h3= t('.rejected')
 .rejected-parcels
   = render 'parcel_table', parcels: @rejected_parcels
-%h3 Zaakceptowane
+%h3= t('.accepted')
 .accepted-parcels
   = render 'parcel_table', parcels: @accepted_parcels

--- a/app/views/employee/parcels/index.html.haml
+++ b/app/views/employee/parcels/index.html.haml
@@ -1,9 +1,9 @@
-%h1
-  Oczekujące przesyłki
+%h1 Przesyłki
+%h3 Oczekujące
 = render 'parcel_table', parcels: @pending_parcels
-%h1
-  Odrzucone przesyłki
-= render 'parcel_table', parcels: @rejected_parcels
-%h1
-  Zaakceptowane przesyłki
-= render 'parcel_table', parcels: @accepted_parcels
+%h3 Odrzucone
+.rejected-parcels
+  = render 'parcel_table', parcels: @rejected_parcels
+%h3 Zaakceptowane
+.accepted-parcels
+  = render 'parcel_table', parcels: @accepted_parcels

--- a/app/views/employee/parcels/index.html.haml
+++ b/app/views/employee/parcels/index.html.haml
@@ -1,18 +1,9 @@
 %h1
-  = t('.parcels')
-%table.table.table-striped.parcels-table
-  %thead
-    %tr
-      %th= Parcel.human_attribute_name('parcel_number')
-      %th= Parcel.human_attribute_name('weight')
-      %th= Parcel.human_attribute_name('price')
-      %th= Parcel.human_attribute_name('created_at')
-      %th= Parcel.human_attribute_name('name')
-  %tbody
-    - @parcels.each do |parcel|
-      %tr
-        %td= parcel.parcel_number
-        %td= number_to_kg(parcel.weight)
-        %td= number_to_currency(parcel.price)
-        %td= l parcel.created_at
-        %td= parcel.name
+  Oczekujące przesyłki
+= render 'parcel_table', parcels: @pending_parcels
+%h1
+  Odrzucone przesyłki
+= render 'parcel_table', parcels: @rejected_parcels
+%h1
+  Zaakceptowane przesyłki
+= render 'parcel_table', parcels: @accepted_parcels

--- a/app/views/parcels/index.html.haml
+++ b/app/views/parcels/index.html.haml
@@ -2,7 +2,7 @@
 %h1
   = t('.your_parcels')
 -if @parcels
-  %table.table.table-striped.parcels-table
+  %table.table.table-striped.centered-text-table
     %thead
       %tr
         %th= Parcel.human_attribute_name('parcel_number')

--- a/app/views/parcels/show.html.haml
+++ b/app/views/parcels/show.html.haml
@@ -1,6 +1,6 @@
 %h1
   =t('.parcel_no', parcel_number: @parcel.parcel_number)
-%table.table.table-striped.parcels-table
+%table.table.table-striped.centered-text-table
   %thead
     %tr
       %th= t('.recipient_city')

--- a/config/locales/default.pl.yml
+++ b/config/locales/default.pl.yml
@@ -1,4 +1,6 @@
 pl:
+  "true": "tak"
+  "false": "nie"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -115,10 +115,13 @@ pl:
     parcels:
       index:
         parcels: 'Przesyłki'
+        pending: 'Oczekujące'
+        rejected: 'Odrzucone'
+        accepted: 'Zaakceptowane'
       edit:
         parcel_no: 'Przesyłka nr %{parcel_number}'
         recipient_city: Miasto odbiorcy
         accept: 'Akceptuj'
         reject: 'Odrzuć'
       update:
-        acceptance_status_changed_succesfully: 'Zapisano nowy status paczki'
+        acceptance_status_changed_succesfully: 'Zmieniono status przesyłki'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -54,6 +54,8 @@ pl:
         company_name: Nazwa firmy
         other_info: Inne informacje
         residential: Adres osoby prywatnej
+      operation:
+        additional_info: Komentarz
   helpers:
     label:
       user:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -125,6 +125,8 @@ pl:
         recipient_city: Miasto odbiorcy
         accept: 'Akceptuj'
         reject: 'Odrzuć'
+        sender: 'Nadawca'
+        recipient: 'Odbiorca'
       update:
         acceptance_status_changed_succesfully: 'Zmieniono status przesyłki'
         acceptance_status_change_not_possible: 'Nie udało się zmienić statusu przesyłki'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -32,6 +32,8 @@ pl:
         price: 'Cena'
         created_at: 'Data utworzenia'
         parcel_number: 'Numer przesyłki'
+        from: Skąd
+        to: Dokąd
       sender_info:
         email: Adres email
         contact_name: Nazwisko osoby kontaktowej
@@ -109,8 +111,8 @@ pl:
         button: 'Zapisz'
   employee:
     parcels:
-      parcel_table:
-        from: Skąd
-        to: Dokąd
       index:
         parcels: 'Przesyłki'
+      edit:
+        parcel_no: 'Przesyłka nr %{parcel_number}'
+        recipient_city: Miasto odbiorcy

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -109,5 +109,8 @@ pl:
         button: 'Zapisz'
   employee:
     parcels:
+      parcel_table:
+        from: Skąd
+        to: Dokąd
       index:
         parcels: 'Przesyłki'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -109,6 +109,8 @@ pl:
       edit:
         parcels_number: 'Liczba przesyłek'
         button: 'Zapisz'
+      update:
+        role_changed_succesfully: 'Zmiana roli zakończyła się powodzeniem'
   employee:
     parcels:
       index:
@@ -118,3 +120,5 @@ pl:
         recipient_city: Miasto odbiorcy
         accept: 'Akceptuj'
         reject: 'Odrzuć'
+      update:
+        acceptance_status_changed_succesfully: 'Zapisano nowy status paczki'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -56,6 +56,7 @@ pl:
         residential: Adres osoby prywatnej
       operation:
         kind: Typ operacji
+        user: Twórca operacji
         created_at: Data utworzenia
         additional_info: Komentarz
         kinds:
@@ -139,6 +140,7 @@ pl:
         sender: 'Nadawca'
         recipient: 'Odbiorca'
         comment: 'Komentarz'
+        previous_operations: 'Wcześniejsze operacje:'
       update:
         acceptance_status_changed_succesfully: 'Zmieniono status przesyłki'
         acceptance_status_change_not_possible: 'Nie udało się zmienić statusu przesyłki'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -116,3 +116,5 @@ pl:
       edit:
         parcel_no: 'Przesyłka nr %{parcel_number}'
         recipient_city: Miasto odbiorcy
+        accept: 'Akceptuj'
+        reject: 'Odrzuć'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -127,6 +127,7 @@ pl:
         reject: 'Odrzuć'
         sender: 'Nadawca'
         recipient: 'Odbiorca'
+        comment: 'Komentarz'
       update:
         acceptance_status_changed_succesfully: 'Zmieniono status przesyłki'
         acceptance_status_change_not_possible: 'Nie udało się zmienić statusu przesyłki'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -55,7 +55,18 @@ pl:
         other_info: Inne informacje
         residential: Adres osoby prywatnej
       operation:
+        kind: Typ operacji
+        created_at: Data utworzenia
         additional_info: Komentarz
+        kinds:
+          order_created: Utworzono zlecenie
+          order_accepted: Przyjęto zlecenie
+          order_rejected: Odrzucono zlecenie
+          parcel_picked_up: Nadano przesyłkę
+          parcel_in_sorting_facility: Przyjęto do sortowni
+          parcel_in_transit: W drodze do oddziału
+          parcel_in_delivery: Przekazano do doręczenia
+          parcel_delivered: Doręczono
   helpers:
     label:
       user:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -125,5 +125,6 @@ pl:
         reject: 'Odrzuć'
       update:
         acceptance_status_changed_succesfully: 'Zmieniono status przesyłki'
+        acceptance_status_change_not_possible: 'Nie udało się zmienić statusu przesyłki'
   navigation:
     back: 'Powrót'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -125,3 +125,5 @@ pl:
         reject: 'Odrzuć'
       update:
         acceptance_status_changed_succesfully: 'Zmieniono status przesyłki'
+  navigation:
+    back: 'Powrót'

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -162,8 +162,9 @@ RSpec.describe Employee::ParcelsController do
   end
 
   shared_examples 'invalid update' do
+    let(:old_acceptance) { edited_parcel.acceptance_status }
+    
     before(:each) do
-      @old_acceptance = edited_parcel.acceptance_status
       put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operation: { additional_info: additional_info } }
       edited_parcel.reload
     end
@@ -173,7 +174,7 @@ RSpec.describe Employee::ParcelsController do
     end
 
     it "doesn't change the parcel status" do
-      expect(edited_parcel.acceptance_status).to eq(@old_acceptance)
+      expect(edited_parcel.acceptance_status).to eq(old_acceptance)
     end
 
     it "doesn't create an operation" do

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -54,52 +54,52 @@ RSpec.describe Employee::ParcelsController do
     end
   end
 
-  # describe "GET #edit" do
-  #   let(:edited_parcel) { FactoryGirl.create(:parcel) }
+  describe "GET #edit" do
+    let(:edited_parcel) { FactoryGirl.create(:parcel) }
 
-  #   context "when user is a client" do
-  #     let(:user) { FactoryGirl.create(:user) }
-  #     it "redirects to applicatioon root" do
-  #       sign_in user
-  #       get :edit, id: edited_parcel
-  #       expect(response).to redirect_to root_path
-  #     end
-  #   end
+    context "when user is a client" do
+      let(:user) { FactoryGirl.create(:user) }
+      it "redirects to applicatioon root" do
+        sign_in user
+        get :edit, id: edited_parcel
+        expect(response).to redirect_to root_path
+      end
+    end
 
-  #   context "when user is an employee" do
-  #     let(:user) { FactoryGirl.create(:user, :employee) }
+    context "when user is an employee" do
+      let(:user) { FactoryGirl.create(:user, :employee) }
 
-  #     before(:each) do
-  #       sign_in user
-  #       get :edit, id: edited_parcel
-  #     end
+      before(:each) do
+        sign_in user
+        get :edit, id: edited_parcel
+      end
 
-  #     it "assigns the requested parcel to @parcel" do
-  #       expect(assigns(:parcel)).to eq(edited_parcel)
-  #     end
+      it "assigns the requested parcel to @parcel" do
+        expect(assigns(:parcel)).to eq(edited_parcel)
+      end
 
-  #     it "renders the :edit view" do
-  #       expect(response).to render_template :edit
-  #     end
-  #   end
+      it "renders the :edit view" do
+        expect(response).to render_template :edit
+      end
+    end
 
-  #   context "when user is admin" do
-  #     let(:user) { FactoryGirl.create(:user, :admin) }
+    context "when user is admin" do
+      let(:user) { FactoryGirl.create(:user, :admin) }
 
-  #     before(:each) do
-  #       sign_in user
-  #       get :edit, id: edited_parcel
-  #     end
+      before(:each) do
+        sign_in user
+        get :edit, id: edited_parcel
+      end
 
-  #     it "assigns the requested parcel to @parcel" do
-  #       expect(assigns(:parcel)).to eq(edited_parcel)
-  #     end
+      it "assigns the requested parcel to @parcel" do
+        expect(assigns(:parcel)).to eq(edited_parcel)
+      end
 
-  #     it "renders the :edit view" do
-  #       expect(response).to render_template :edit
-  #     end
-  #   end
-  # end
+      it "renders the :edit view" do
+        expect(response).to render_template :edit
+      end
+    end
+  end
 
   # describe "PUT #update" do
 

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -139,10 +139,70 @@ RSpec.describe Employee::ParcelsController do
     end
   end
 
+  shared_examples 'valid update' do
+    before(:each) do
+      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { additional_info: additional_info } }
+      edited_parcel.reload
+    end
+
+    it "redirects to index" do
+      expect(response).to redirect_to action: "index"
+    end
+
+    it "updates the parcel" do
+      expect(edited_parcel.acceptance_status).to eq(acceptance_status)
+    end
+
+    it "creates an operation" do
+      expect(edited_parcel.operations.last.user).to eq(user)
+    end
+
+    context 'when additional_info is included' do
+      let(:additional_info) { 'additional info' }
+      it "redirects to index" do
+        expect(response).to redirect_to action: "index"
+      end
+
+      it "updates the parcel" do
+        expect(edited_parcel.acceptance_status).to eq(acceptance_status)
+      end
+
+      it "creates an operation" do
+        expect(edited_parcel.operations.last.user).to eq(user)
+      end
+
+      it "includes additional_info in the operation" do
+        expect(edited_parcel.operations.last.additional_info).to eq(additional_info)
+      end
+    end
+  end
+
+  shared_examples 'invalid update' do
+    before(:each) do
+      @old_acceptance = edited_parcel.acceptance_status
+      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { additional_info: additional_info } }
+      edited_parcel.reload
+    end
+
+    it "redirects to index" do
+      expect(response).to redirect_to action: "index"
+    end
+
+    it "doesn't change the parcel status" do
+      expect(edited_parcel.acceptance_status).to eq(@old_acceptance)
+    end
+
+    it "doesn't create an operation" do
+      expect(edited_parcel.operations.last.user).not_to eq(user)
+    end
+  end
+
   describe "PUT #update" do
     before(:each) do
       sign_in user
     end
+
+    let(:additional_info) { '' }
 
     context "when user is a client" do
       let(:user) { FactoryGirl.create(:user) }
@@ -168,41 +228,15 @@ RSpec.describe Employee::ParcelsController do
         let(:edited_parcel) { FactoryGirl.create(:parcel) }
 
         context "accepting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'accepted' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('accepted')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'         
         end
 
         context "rejecting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'rejected' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('rejected')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'
         end
       end
 
@@ -210,41 +244,15 @@ RSpec.describe Employee::ParcelsController do
         let(:edited_parcel) { FactoryGirl.create(:parcel, :accepted) }
 
         context "accepting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'accepted' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "doesn't change the parcel status" do
-            expect(edited_parcel.acceptance_status).to eq('accepted')
-          end
-
-          it "doesn't create an operation" do
-            expect(edited_parcel.operations.last.user).not_to eq(user)
-          end
+          include_examples 'invalid update'
         end
 
         context "rejecting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'rejected' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('rejected')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'
         end
       end
 
@@ -252,41 +260,15 @@ RSpec.describe Employee::ParcelsController do
         let(:edited_parcel) { FactoryGirl.create(:parcel, :rejected) }
 
         context "accepting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'accepted' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('accepted')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'
         end
 
         context "rejecting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'rejected' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "doesn't change the parcel status" do
-            expect(edited_parcel.acceptance_status).to eq('rejected')
-          end
-
-          it "doesn't create an operation" do
-            expect(edited_parcel.operations.last.user).not_to eq(user)
-          end
+          include_examples 'invalid update'
         end
       end
     end
@@ -298,41 +280,15 @@ RSpec.describe Employee::ParcelsController do
         let(:edited_parcel) { FactoryGirl.create(:parcel) }
 
         context "accepting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'accepted' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('accepted')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'         
         end
 
         context "rejecting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'rejected' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('rejected')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'
         end
       end
 
@@ -340,41 +296,15 @@ RSpec.describe Employee::ParcelsController do
         let(:edited_parcel) { FactoryGirl.create(:parcel, :accepted) }
 
         context "accepting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'accepted' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "doesn't change the parcel status" do
-            expect(edited_parcel.acceptance_status).to eq('accepted')
-          end
-
-          it "doesn't create an operation" do
-            expect(edited_parcel.operations.last.user).not_to eq(user)
-          end
+          include_examples 'invalid update'
         end
 
         context "rejecting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'rejected' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('rejected')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'
         end
       end
 
@@ -382,41 +312,15 @@ RSpec.describe Employee::ParcelsController do
         let(:edited_parcel) { FactoryGirl.create(:parcel, :rejected) }
 
         context "accepting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'accepted' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "updates the parcel" do
-            expect(edited_parcel.acceptance_status).to eq('accepted')
-          end
-
-          it "creates an operation" do
-            expect(edited_parcel.operations.last.user).to eq(user)
-          end
+          include_examples 'valid update'
         end
 
         context "rejecting the parcel" do
-          before(:each) do
-            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_parcel.reload
-          end
+          let(:acceptance_status) { 'rejected' }
 
-          it "redirects to index" do
-            expect(response).to redirect_to action: "index"
-          end
-
-          it "doesn't change the parcel status" do
-            expect(edited_parcel.acceptance_status).to eq('rejected')
-          end
-
-          it "doesn't create an operation" do
-            expect(edited_parcel.operations.last.user).not_to eq(user)
-          end
+          include_examples 'invalid update'
         end
       end
     end

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Employee::ParcelsController do
 
   shared_examples 'valid update' do
     before(:each) do
-      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { '0' => { additional_info: additional_info } } }
+      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operation: { additional_info: additional_info } }
       edited_parcel.reload
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Employee::ParcelsController do
   shared_examples 'invalid update' do
     before(:each) do
       @old_acceptance = edited_parcel.acceptance_status
-      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { '0' => { additional_info: additional_info } } }
+      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operation: { additional_info: additional_info } }
       edited_parcel.reload
     end
 

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Employee::ParcelsController do
       let(:edited_parcel) { FactoryGirl.create(:parcel) }
 
       before(:each) do
-        put :update, id: edited_parcel.id, user: {acceptance_status: 'accepted'}
+        put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
       end
 
       it "redirects to applicatioon root" do
@@ -163,10 +163,6 @@ RSpec.describe Employee::ParcelsController do
 
     context "when user is an employee" do
       let(:user) { FactoryGirl.create(:user, :employee) }
-    end
-
-    context "when user is admin" do
-      let(:user) { FactoryGirl.create(:user, :admin) }
 
       context "when parcel is pending" do
         let(:edited_parcel) { FactoryGirl.create(:parcel) }
@@ -193,7 +189,7 @@ RSpec.describe Employee::ParcelsController do
         context "rejecting the parcel" do
           before(:each) do
             put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_user.reload
+            edited_parcel.reload
           end
 
           it "redirects to index" do
@@ -235,7 +231,7 @@ RSpec.describe Employee::ParcelsController do
         context "rejecting the parcel" do
           before(:each) do
             put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
-            edited_user.reload
+            edited_parcel.reload
           end
 
           it "redirects to index" do
@@ -258,7 +254,7 @@ RSpec.describe Employee::ParcelsController do
         context "accepting the parcel" do
           before(:each) do
             put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
-            edited_user.reload
+            edited_parcel.reload
           end
 
           it "redirects to index" do
@@ -273,7 +269,137 @@ RSpec.describe Employee::ParcelsController do
             expect(edited_parcel.operations.last.user).to eq(user)
           end
         end
-        
+
+        context "rejecting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "doesn't change the parcel status" do
+            expect(edited_parcel.acceptance_status).to eq('rejected')
+          end
+
+          it "doesn't create an operation" do
+            expect(edited_parcel.operations.last.user).not_to eq(user)
+          end
+        end
+      end
+    end
+
+    context "when user is admin" do
+      let(:user) { FactoryGirl.create(:user, :admin) }
+
+      context "when parcel is pending" do
+        let(:edited_parcel) { FactoryGirl.create(:parcel) }
+
+        context "accepting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('accepted')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+
+        context "rejecting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('rejected')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+      end
+
+      context "when parcel is accepted" do
+        let(:edited_parcel) { FactoryGirl.create(:parcel, :accepted) }
+
+        context "accepting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "doesn't change the parcel status" do
+            expect(edited_parcel.acceptance_status).to eq('accepted')
+          end
+
+          it "doesn't create an operation" do
+            expect(edited_parcel.operations.last.user).not_to eq(user)
+          end
+        end
+
+        context "rejecting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('rejected')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+      end
+
+      context "when parcel is rejected" do
+        let(:edited_parcel) { FactoryGirl.create(:parcel, :rejected) }
+
+        context "accepting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('accepted')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+
         context "rejecting the parcel" do
           before(:each) do
             put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 RSpec.describe Employee::ParcelsController do
   describe "GET #index" do
     before(:each) do
-      FactoryGirl.create_list(:parcel, 5)
+      FactoryGirl.create_list(:parcel, 3)
+      FactoryGirl.create_list(:parcel, 3, :accepted)
+      FactoryGirl.create_list(:parcel, 3, :rejected)
     end
 
     context "when user is a client" do
@@ -23,12 +25,28 @@ RSpec.describe Employee::ParcelsController do
         get :index
       end
 
-      it "populates @parcels array with all parcels in the DB" do
-        expect(assigns(:parcels)).to match_array(Parcel.all)
+      it "populates @pending_parcels array with all pending parcels in the DB" do
+        expect(assigns(:pending_parcels)).to match_array(Parcel.pending)
       end
 
-      it "assigns the newest parcel first" do
-        expect(assigns(:parcels)[0]).to eq(Parcel.last)
+      it "assigns the newest pending parcel first" do
+        expect(assigns(:pending_parcels)[0]).to eq(Parcel.pending.last)
+      end
+
+      it "populates @accepted_parcels array with all accepted parcels in the DB" do
+        expect(assigns(:accepted_parcels)).to match_array(Parcel.accepted)
+      end
+
+      it "assigns the newest accepted parcel first" do
+        expect(assigns(:accepted_parcels)[0]).to eq(Parcel.accepted.last)
+      end
+
+      it "populates @rejected_parcels array with all rejected parcels in the DB" do
+        expect(assigns(:rejected_parcels)).to match_array(Parcel.rejected)
+      end
+
+      it "assigns the newest rejected parcel first" do
+        expect(assigns(:rejected_parcels)[0]).to eq(Parcel.rejected.last)
       end
 
       it "renders the :index view" do
@@ -44,12 +62,28 @@ RSpec.describe Employee::ParcelsController do
         get :index
       end
 
-      it "populates @parcels array with all parcels in the DB" do
-        expect(assigns(:parcels)).to match_array(Parcel.all)
+      it "populates @pending_parcels array with all pending parcels in the DB" do
+        expect(assigns(:pending_parcels)).to match_array(Parcel.pending)
       end
 
-      it "assigns the newest parcel first" do
-        expect(assigns(:parcels)[0]).to eq(Parcel.last)
+      it "assigns the newest pending parcel first" do
+        expect(assigns(:pending_parcels)[0]).to eq(Parcel.pending.last)
+      end
+
+      it "populates @accepted_parcels array with all accepted parcels in the DB" do
+        expect(assigns(:accepted_parcels)).to match_array(Parcel.accepted)
+      end
+
+      it "assigns the newest accepted parcel first" do
+        expect(assigns(:accepted_parcels)[0]).to eq(Parcel.accepted.last)
+      end
+
+      it "populates @rejected_parcels array with all rejected parcels in the DB" do
+        expect(assigns(:rejected_parcels)).to match_array(Parcel.rejected)
+      end
+
+      it "assigns the newest rejected parcel first" do
+        expect(assigns(:rejected_parcels)[0]).to eq(Parcel.rejected.last)
       end
 
       it "renders the :index view" do

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Employee::ParcelsController do
 
   shared_examples 'valid update' do
     before(:each) do
-      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { additional_info: additional_info } }
+      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { '0' => { additional_info: additional_info } } }
       edited_parcel.reload
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Employee::ParcelsController do
   shared_examples 'invalid update' do
     before(:each) do
       @old_acceptance = edited_parcel.acceptance_status
-      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { additional_info: additional_info } }
+      put :update, id: edited_parcel.id, parcel: { acceptance_status: acceptance_status, operations_attributes: { '0' => { additional_info: additional_info } } }
       edited_parcel.reload
     end
 

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -6,24 +6,20 @@ RSpec.describe Employee::ParcelsController do
       FactoryGirl.create_list(:parcel, 3)
       FactoryGirl.create_list(:parcel, 3, :accepted)
       FactoryGirl.create_list(:parcel, 3, :rejected)
+
+      sign_in user
+      get :index
     end
 
     context "when user is a client" do
       let(:user) { FactoryGirl.create(:user) }
       it "redirects to applicatioon root" do
-        sign_in user
-        get :index
         expect(response).to redirect_to root_path
       end
     end
 
     context "when user is an employee" do
       let(:user) { FactoryGirl.create(:user, :employee) }
-
-      before(:each) do
-        sign_in user
-        get :index
-      end
 
       it "populates @pending_parcels array with all pending parcels in the DB" do
         expect(assigns(:pending_parcels)).to match_array(Parcel.pending)
@@ -56,11 +52,6 @@ RSpec.describe Employee::ParcelsController do
 
     context "when user is admin" do
       let(:user) { FactoryGirl.create(:user, :admin) }
-
-      before(:each) do
-        sign_in user
-        get :index
-      end
 
       it "populates @pending_parcels array with all pending parcels in the DB" do
         expect(assigns(:pending_parcels)).to match_array(Parcel.pending)
@@ -95,22 +86,20 @@ RSpec.describe Employee::ParcelsController do
   describe "GET #edit" do
     let(:edited_parcel) { FactoryGirl.create(:parcel) }
 
+    before(:each) do
+      sign_in user
+      get :edit, id: edited_parcel
+    end
+
     context "when user is a client" do
       let(:user) { FactoryGirl.create(:user) }
       it "redirects to applicatioon root" do
-        sign_in user
-        get :edit, id: edited_parcel
         expect(response).to redirect_to root_path
       end
     end
 
     context "when user is an employee" do
       let(:user) { FactoryGirl.create(:user, :employee) }
-
-      before(:each) do
-        sign_in user
-        get :edit, id: edited_parcel
-      end
 
       it "assigns the requested parcel to @parcel" do
         expect(assigns(:parcel)).to eq(edited_parcel)
@@ -123,11 +112,6 @@ RSpec.describe Employee::ParcelsController do
 
     context "when user is admin" do
       let(:user) { FactoryGirl.create(:user, :admin) }
-
-      before(:each) do
-        sign_in user
-        get :edit, id: edited_parcel
-      end
 
       it "assigns the requested parcel to @parcel" do
         expect(assigns(:parcel)).to eq(edited_parcel)

--- a/spec/controllers/employee/parcels_controller_spec.rb
+++ b/spec/controllers/employee/parcels_controller_spec.rb
@@ -139,7 +139,160 @@ RSpec.describe Employee::ParcelsController do
     end
   end
 
-  # describe "PUT #update" do
+  describe "PUT #update" do
+    before(:each) do
+      sign_in user
+    end
 
-  # end
+    context "when user is a client" do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:edited_parcel) { FactoryGirl.create(:parcel) }
+
+      before(:each) do
+        put :update, id: edited_parcel.id, user: {acceptance_status: 'accepted'}
+      end
+
+      it "redirects to applicatioon root" do
+        expect(response).to redirect_to root_path
+      end
+
+      it "doesn't change the user" do
+        expect(edited_parcel.acceptance_status).to eq('pending')
+      end
+    end
+
+    context "when user is an employee" do
+      let(:user) { FactoryGirl.create(:user, :employee) }
+    end
+
+    context "when user is admin" do
+      let(:user) { FactoryGirl.create(:user, :admin) }
+
+      context "when parcel is pending" do
+        let(:edited_parcel) { FactoryGirl.create(:parcel) }
+
+        context "accepting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('accepted')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+
+        context "rejecting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
+            edited_user.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('rejected')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+      end
+
+      context "when parcel is accepted" do
+        let(:edited_parcel) { FactoryGirl.create(:parcel, :accepted) }
+
+        context "accepting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "doesn't change the parcel status" do
+            expect(edited_parcel.acceptance_status).to eq('accepted')
+          end
+
+          it "doesn't create an operation" do
+            expect(edited_parcel.operations.last.user).not_to eq(user)
+          end
+        end
+
+        context "rejecting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
+            edited_user.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('rejected')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+      end
+
+      context "when parcel is rejected" do
+        let(:edited_parcel) { FactoryGirl.create(:parcel, :rejected) }
+
+        context "accepting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'accepted'}
+            edited_user.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "updates the parcel" do
+            expect(edited_parcel.acceptance_status).to eq('accepted')
+          end
+
+          it "creates an operation" do
+            expect(edited_parcel.operations.last.user).to eq(user)
+          end
+        end
+        
+        context "rejecting the parcel" do
+          before(:each) do
+            put :update, id: edited_parcel.id, parcel: {acceptance_status: 'rejected'}
+            edited_parcel.reload
+          end
+
+          it "redirects to index" do
+            expect(response).to redirect_to action: "index"
+          end
+
+          it "doesn't change the parcel status" do
+            expect(edited_parcel.acceptance_status).to eq('rejected')
+          end
+
+          it "doesn't create an operation" do
+            expect(edited_parcel.operations.last.user).not_to eq(user)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/services/parcel_acceptance_service_spec.rb
+++ b/spec/services/parcel_acceptance_service_spec.rb
@@ -2,44 +2,45 @@ require 'rails_helper'
 
 RSpec.shared_examples 'change of acceptance' do
   it 'returns true' do
-    expect(ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call).to be true
+    expect(service.call).to be true
   end
 
   it 'changes the parcel status' do
-    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+    service.call
     expect(parcel.acceptance_status).to eq(acceptance_status)
   end
 
   it 'creates an operation of requested kind' do
-    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+    service.call
     expect(parcel.operations.last.kind).to eq(operation_kind)
   end
 
   it 'assigns requested additional_info to operation' do
-    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+    service.call
     expect(parcel.operations.last.additional_info).to eq(additional_info)
   end
 end
 
 RSpec.shared_examples 'nothing changes' do
   it 'returns false' do
-    expect(ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call).to be false
+    expect(service.call).to be false
   end
 
   it 'does not change the parcel status' do
     old_status = parcel.acceptance_status
-    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+    service.call
     expect(parcel.acceptance_status).to eq(old_status)
   end
 
   it 'does not create an operation' do
     last_operation = parcel.operations.last
-    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+    service.call
     expect(parcel.operations.last).to eq(last_operation)
   end
 end
 
 RSpec.describe ParcelAcceptanceService do
+  let(:service) { ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info) }
   let(:additional_info) { nil }
 
   describe 'accepting pending parcel' do
@@ -62,7 +63,7 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+        service.call
         expect(parcel.operations.last.user).to eq(author)
       end
 
@@ -93,7 +94,7 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+        service.call
         expect(parcel.operations.last.user).to eq(author)
       end
 
@@ -124,7 +125,7 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+        service.call
         expect(parcel.operations.last.user).to eq(author)
       end
 
@@ -155,7 +156,7 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+        service.call
         expect(parcel.operations.last.user).to eq(author)
       end
 

--- a/spec/services/parcel_acceptance_service_spec.rb
+++ b/spec/services/parcel_acceptance_service_spec.rb
@@ -2,47 +2,59 @@ require 'rails_helper'
 
 RSpec.shared_examples 'change of acceptance' do
   it 'returns true' do
-    expect(ParcelAcceptanceService.new(parcel, acceptance_status, author).call).to be true
+    expect(ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call).to be true
   end
 
   it 'changes the parcel status' do
-    ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
     expect(parcel.acceptance_status).to eq(acceptance_status)
   end
 
   it 'creates an operation of requested kind' do
-    ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
     expect(parcel.operations.last.kind).to eq(operation_kind)
+  end
+
+  it 'assigns requested additional_info to operation' do
+    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
+    expect(parcel.operations.last.additional_info).to eq(additional_info)
   end
 end
 
 RSpec.shared_examples 'nothing changes' do
   it 'returns false' do
-    expect(ParcelAcceptanceService.new(parcel, acceptance_status, author).call).to be false
+    expect(ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call).to be false
   end
 
   it 'does not change the parcel status' do
     old_status = parcel.acceptance_status
-    ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
     expect(parcel.acceptance_status).to eq(old_status)
   end
 
   it 'does not create an operation' do
     last_operation = parcel.operations.last
-    ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+    ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
     expect(parcel.operations.last).to eq(last_operation)
   end
 end
 
 RSpec.describe ParcelAcceptanceService do
+  let(:additional_info) { nil }
+
   describe 'accepting pending parcel' do
     let(:parcel) { FactoryGirl.create(:parcel) }
     let(:acceptance_status) { 'accepted' }
-    let(:operation_kind) { 'order_accepted' }
+    let(:operation_kind) { 'order_accepted' }  
 
     context 'without an author' do
       let(:author) { nil }
       include_examples 'change of acceptance'
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
+      end
     end
 
     context 'with an author' do
@@ -50,8 +62,13 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
         expect(parcel.operations.last.user).to eq(author)
+      end
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
       end
     end
   end
@@ -64,6 +81,11 @@ RSpec.describe ParcelAcceptanceService do
     context 'without an author' do
       let(:author) { nil }
       include_examples 'change of acceptance'
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
+      end
     end
 
     context 'with an author' do
@@ -71,8 +93,13 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
         expect(parcel.operations.last.user).to eq(author)
+      end
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
       end
     end
   end
@@ -85,6 +112,11 @@ RSpec.describe ParcelAcceptanceService do
     context 'without an author' do
       let(:author) { nil }
       include_examples 'change of acceptance'
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
+      end
     end
 
     context 'with an author' do
@@ -92,8 +124,13 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
         expect(parcel.operations.last.user).to eq(author)
+      end
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
       end
     end
   end
@@ -106,6 +143,11 @@ RSpec.describe ParcelAcceptanceService do
     context 'without an author' do
       let(:author) { nil }
       include_examples 'change of acceptance'
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
+      end
     end
 
     context 'with an author' do
@@ -113,8 +155,13 @@ RSpec.describe ParcelAcceptanceService do
       include_examples 'change of acceptance'
       
       it 'sets the operation author correctly' do
-        ParcelAcceptanceService.new(parcel, acceptance_status, author).call
+        ParcelAcceptanceService.new(parcel, acceptance_status, author, additional_info).call
         expect(parcel.operations.last.user).to eq(author)
+      end
+
+      context 'with additional_info' do
+        let(:additional_info) { 'additional info' }
+        include_examples 'change of acceptance'
       end
     end
   end

--- a/spec/services/parcel_acceptance_service_spec.rb
+++ b/spec/services/parcel_acceptance_service_spec.rb
@@ -10,7 +10,13 @@ RSpec.shared_examples 'change of acceptance' do
     expect(parcel.acceptance_status).to eq(acceptance_status)
   end
 
-  it 'creates an operation of requested kind' do
+  it 'creates an operation' do
+    expect{
+      service.call
+    }.to change(parcel.operations,:count).by(1)
+  end
+
+  it 'created operation has requested kind' do
     service.call
     expect(parcel.operations.last.kind).to eq(operation_kind)
   end


### PR DESCRIPTION
Pracownik ma akcje edit i update, i może za ich pomocą przyjąć i odrzucić przesyłkę (zostawiając komentarz).
Kontroler przekierowuje request do utworzonego wcześniej serwisu.
W widoku edit wyświetlają się przeszłe operacje na przesyłce.

Tu było dużo siłowania się z automagią, ale chodzi bardzo ładnie.
